### PR TITLE
Refactor create-mode input handling around unified sources

### DIFF
--- a/packages/engine/create_local_records_test.go
+++ b/packages/engine/create_local_records_test.go
@@ -1,0 +1,162 @@
+package engine
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/islishude/gotgz/packages/cli"
+)
+
+// recordingTarWriter captures tar headers and payloads written during tests.
+type recordingTarWriter struct {
+	headers []*tar.Header
+	bodies  [][]byte
+	current bytes.Buffer
+}
+
+// WriteHeader records one tar header and resets the current payload buffer.
+func (w *recordingTarWriter) WriteHeader(hdr *tar.Header) error {
+	cloned := *hdr
+	w.headers = append(w.headers, &cloned)
+	w.current.Reset()
+	return nil
+}
+
+// Write appends file data to the current payload buffer.
+func (w *recordingTarWriter) Write(p []byte) (int, error) {
+	return w.current.Write(p)
+}
+
+// FinishEntry stores the payload accumulated for the current tar member.
+func (w *recordingTarWriter) FinishEntry() error {
+	w.bodies = append(w.bodies, bytes.Clone(w.current.Bytes()))
+	w.current.Reset()
+	return nil
+}
+
+// Close satisfies the tarArchiveWriter interface for tests.
+func (w *recordingTarWriter) Close() error {
+	return nil
+}
+
+// recordingZipWriter captures zip headers and payloads written during tests.
+type recordingZipWriter struct {
+	headers []*zip.FileHeader
+	bodies  [][]byte
+	current *bytes.Buffer
+}
+
+// CreateHeader records one zip header and starts a new payload buffer.
+func (w *recordingZipWriter) CreateHeader(hdr *zip.FileHeader) (io.Writer, error) {
+	cloned := *hdr
+	w.headers = append(w.headers, &cloned)
+	w.current = &bytes.Buffer{}
+	return w.current, nil
+}
+
+// FinishEntry stores the payload accumulated for the current zip member.
+func (w *recordingZipWriter) FinishEntry() error {
+	if w.current == nil {
+		w.bodies = append(w.bodies, nil)
+		return nil
+	}
+	w.bodies = append(w.bodies, bytes.Clone(w.current.Bytes()))
+	w.current = nil
+	return nil
+}
+
+// Close satisfies the zipArchiveWriter interface for tests.
+func (w *recordingZipWriter) Close() error {
+	return nil
+}
+
+func TestAddLocalRecordsUsesCurrentTarMetadata(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file.txt")
+	if err := os.WriteFile(path, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runner := &Runner{}
+	plan, err := runner.buildCreatePlan(context.Background(), cli.Options{
+		Members: []string{"file.txt"},
+		Chdir:   root,
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildCreatePlan() error = %v", err)
+	}
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	writer := &recordingTarWriter{}
+	warnings, err := runner.addLocalTarSource(context.Background(), writer, plannedLocalCreateSource{records: plan.members[0].localRecords}, false, MetadataPolicy{}, nil)
+	if err != nil {
+		t.Fatalf("addLocalTarSource() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("warnings = %d, want 0", warnings)
+	}
+	if len(writer.headers) != 1 {
+		t.Fatalf("header count = %d, want 1", len(writer.headers))
+	}
+	if got, want := writer.headers[0].Mode&0o777, int64(0o755); got != want {
+		t.Fatalf("header mode = %o, want %o", got, want)
+	}
+	if len(writer.bodies) != 1 {
+		t.Fatalf("body count = %d, want 1", len(writer.bodies))
+	}
+	if got, want := string(writer.bodies[0]), "payload"; got != want {
+		t.Fatalf("payload = %q, want %q", got, want)
+	}
+}
+
+func TestAddLocalRecordsZipUsesCurrentMetadata(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file.txt")
+	if err := os.WriteFile(path, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runner := &Runner{}
+	plan, err := runner.buildCreatePlan(context.Background(), cli.Options{
+		Members: []string{"file.txt"},
+		Chdir:   root,
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildCreatePlan() error = %v", err)
+	}
+
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	writer := &recordingZipWriter{}
+	warnings, err := runner.addLocalZipSource(context.Background(), writer, plannedLocalCreateSource{records: plan.members[0].localRecords}, false, nil)
+	if err != nil {
+		t.Fatalf("addLocalZipSource() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("warnings = %d, want 0", warnings)
+	}
+	if len(writer.headers) != 1 {
+		t.Fatalf("header count = %d, want 1", len(writer.headers))
+	}
+	if got, want := writer.headers[0].Mode().Perm(), fs.FileMode(0o755); got != want {
+		t.Fatalf("header mode = %o, want %o", got, want)
+	}
+	if len(writer.bodies) != 1 {
+		t.Fatalf("body count = %d, want 1", len(writer.bodies))
+	}
+	if got, want := string(writer.bodies[0]), "payload"; got != want {
+		t.Fatalf("payload = %q, want %q", got, want)
+	}
+}

--- a/packages/engine/create_plan.go
+++ b/packages/engine/create_plan.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/islishude/gotgz/packages/archivepath"
-	"github.com/islishude/gotgz/packages/archiveprogress"
 	"github.com/islishude/gotgz/packages/cli"
 	"github.com/islishude/gotgz/packages/locator"
 )
@@ -19,10 +18,10 @@ type createPlan struct {
 }
 
 // createPlanMember stores one parsed create input and any pre-scanned local
-// entries associated with it.
+// records associated with it.
 type createPlanMember struct {
 	ref          locator.Ref
-	localEntries []localCreateEntry
+	localRecords []localCreateRecord
 }
 
 // buildCreatePlan parses create members once, caches local walk results, and
@@ -61,16 +60,16 @@ func (r *Runner) buildCreatePlan(ctx context.Context, opts cli.Options, excludeM
 			}
 			plan.totalBytes += meta.Size
 		case locator.KindLocal:
-			entries, size, err := r.collectLocalCreateEntries(ctx, member, opts.Chdir, excludeMatcher)
+			records, size, err := collectLocalCreateRecords(ctx, member, opts.Chdir, excludeMatcher)
 			if err != nil {
 				return nil, err
 			}
-			if len(entries) == 0 {
+			if len(records) == 0 {
 				continue
 			}
 			plan.members = append(plan.members, createPlanMember{
 				ref:          ref,
-				localEntries: entries,
+				localRecords: records,
 			})
 			plan.totalBytes += size
 		default:
@@ -78,45 +77,4 @@ func (r *Runner) buildCreatePlan(ctx context.Context, opts cli.Options, excludeM
 		}
 	}
 	return plan, nil
-}
-
-// buildCreatePlanIfEnabled creates a reusable plan only when progress output is
-// active and total-byte estimation is therefore useful.
-func (r *Runner) buildCreatePlanIfEnabled(ctx context.Context, opts cli.Options, excludeMatcher *archivepath.CompiledPathMatcher, reporter *archiveprogress.Reporter) (*createPlan, error) {
-	if reporter == nil || !reporter.Enabled() {
-		return nil, nil
-	}
-	plan, err := r.buildCreatePlan(ctx, opts, excludeMatcher)
-	if err != nil {
-		return nil, err
-	}
-	reporter.SetTotal(plan.totalBytes, plan.totalKnown)
-	return plan, nil
-}
-
-// processCreatePlan dispatches one pre-scanned create plan to the format-
-// specific writers without rescanning local filesystem trees.
-func (r *Runner) processCreatePlan(ctx context.Context, plan *createPlan, handleS3 func(ref locator.Ref) error, handleLocal func(entries []localCreateEntry) (int, error)) (int, error) {
-	warnings := 0
-	for _, member := range plan.members {
-		select {
-		case <-ctx.Done():
-			return warnings, ctx.Err()
-		default:
-		}
-
-		switch member.ref.Kind {
-		case locator.KindS3:
-			if err := handleS3(member.ref); err != nil {
-				return warnings, err
-			}
-		case locator.KindLocal:
-			w, err := handleLocal(member.localEntries)
-			warnings += w
-			if err != nil {
-				return warnings, err
-			}
-		}
-	}
-	return warnings, nil
 }

--- a/packages/engine/create_plan_test.go
+++ b/packages/engine/create_plan_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,22 +43,22 @@ func TestBuildCreatePlanReusesLocalEntriesAfterMutation(t *testing.T) {
 	}
 
 	var seen []string
-	warnings, err := (&Runner{}).processCreatePlan(
+	warnings, err := plannedCreateInputSource{plan: plan}.Visit(
 		context.Background(),
-		plan,
 		func(ref locator.Ref) error {
 			t.Fatalf("unexpected s3 member: %+v", ref)
 			return nil
 		},
-		func(entries []localCreateEntry) (int, error) {
-			for _, entry := range entries {
-				seen = append(seen, entry.archiveName)
-			}
-			return 0, nil
+		func(source localCreateSource) (int, error) {
+			err := source.Visit(context.Background(), func(record localCreateRecord, _ fs.FileInfo) error {
+				seen = append(seen, record.archiveName)
+				return nil
+			})
+			return 0, err
 		},
 	)
 	if err != nil {
-		t.Fatalf("processCreatePlan() error = %v", err)
+		t.Fatalf("Visit() error = %v", err)
 	}
 	if warnings != 0 {
 		t.Fatalf("warnings = %d, want 0", warnings)
@@ -98,7 +99,7 @@ func TestBuildCreatePlanContinuesLocalScanAfterS3StatFailure(t *testing.T) {
 	if len(plan.members) != 2 {
 		t.Fatalf("member count = %d, want 2", len(plan.members))
 	}
-	if len(plan.members[1].localEntries) == 0 {
-		t.Fatal("local entries should still be scanned after s3 stat failure")
+	if len(plan.members[1].localRecords) == 0 {
+		t.Fatal("local records should still be scanned after s3 stat failure")
 	}
 }

--- a/packages/engine/create_source.go
+++ b/packages/engine/create_source.go
@@ -1,0 +1,180 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/islishude/gotgz/packages/archivepath"
+	"github.com/islishude/gotgz/packages/cli"
+	"github.com/islishude/gotgz/packages/locator"
+)
+
+// localCreateSource provides one local create workload as normalized archive
+// records paired with the current filesystem metadata used to write them.
+type localCreateSource interface {
+	Visit(ctx context.Context, visit func(record localCreateRecord, info fs.FileInfo) error) error
+}
+
+// liveLocalCreateSource walks one local member directly from the filesystem.
+type liveLocalCreateSource struct {
+	member         string
+	chdir          string
+	excludeMatcher *archivepath.CompiledPathMatcher
+}
+
+// Visit streams one live local member walk to the supplied visitor.
+func (s liveLocalCreateSource) Visit(ctx context.Context, visit func(record localCreateRecord, info fs.FileInfo) error) error {
+	return walkLocalCreateMember(ctx, s.member, s.chdir, s.excludeMatcher, visit)
+}
+
+// plannedLocalCreateSource replays one pre-scanned local record list using
+// fresh filesystem metadata at write time.
+type plannedLocalCreateSource struct {
+	records []localCreateRecord
+}
+
+// Visit replays one planned local member list while refreshing metadata for
+// each record just before it is written.
+func (s plannedLocalCreateSource) Visit(ctx context.Context, visit func(record localCreateRecord, info fs.FileInfo) error) error {
+	for _, record := range s.records {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		info, err := os.Lstat(record.current)
+		if err != nil {
+			return err
+		}
+		if err := visit(record, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createInputSource dispatches create-mode members and exposes any known total
+// payload size for progress reporting.
+type createInputSource interface {
+	Total() (int64, bool)
+	Visit(ctx context.Context, handleS3 func(ref locator.Ref) error, handleLocal func(source localCreateSource) (int, error)) (int, error)
+}
+
+// liveCreateInputSource parses create members on demand without precomputing a plan.
+type liveCreateInputSource struct {
+	opts           cli.Options
+	excludeMatcher *archivepath.CompiledPathMatcher
+}
+
+// Total reports that live create sources do not know their payload size upfront.
+func (s liveCreateInputSource) Total() (int64, bool) {
+	return 0, false
+}
+
+// Visit parses each create member and dispatches it by backend kind.
+func (s liveCreateInputSource) Visit(ctx context.Context, handleS3 func(ref locator.Ref) error, handleLocal func(source localCreateSource) (int, error)) (int, error) {
+	warnings := 0
+	for _, member := range s.opts.Members {
+		select {
+		case <-ctx.Done():
+			return warnings, ctx.Err()
+		default:
+		}
+
+		ref, err := locator.ParseMember(member)
+		if err != nil {
+			return warnings, err
+		}
+
+		switch ref.Kind {
+		case locator.KindS3:
+			if archivepath.MatchExcludeWithMatcher(s.excludeMatcher, ref.Key) {
+				continue
+			}
+			if err := handleS3(ref); err != nil {
+				return warnings, err
+			}
+		case locator.KindLocal:
+			w, err := handleLocal(liveLocalCreateSource{
+				member:         member,
+				chdir:          s.opts.Chdir,
+				excludeMatcher: s.excludeMatcher,
+			})
+			warnings += w
+			if err != nil {
+				return warnings, err
+			}
+		default:
+			return warnings, fmt.Errorf("unsupported member reference %q", member)
+		}
+	}
+	return warnings, nil
+}
+
+// plannedCreateInputSource replays one pre-scanned create plan.
+type plannedCreateInputSource struct {
+	plan *createPlan
+}
+
+// Total reports the pre-scanned payload size estimate attached to the plan.
+func (s plannedCreateInputSource) Total() (int64, bool) {
+	return s.plan.totalBytes, s.plan.totalKnown
+}
+
+// Visit dispatches each pre-scanned create member without rescanning local trees.
+func (s plannedCreateInputSource) Visit(ctx context.Context, handleS3 func(ref locator.Ref) error, handleLocal func(source localCreateSource) (int, error)) (int, error) {
+	warnings := 0
+	for _, member := range s.plan.members {
+		select {
+		case <-ctx.Done():
+			return warnings, ctx.Err()
+		default:
+		}
+
+		switch member.ref.Kind {
+		case locator.KindS3:
+			if err := handleS3(member.ref); err != nil {
+				return warnings, err
+			}
+		case locator.KindLocal:
+			w, err := handleLocal(plannedLocalCreateSource{records: member.localRecords})
+			warnings += w
+			if err != nil {
+				return warnings, err
+			}
+		}
+	}
+	return warnings, nil
+}
+
+// newCreateInputSource chooses a live or pre-scanned create source depending on
+// whether the caller needs an upfront total for progress reporting.
+func (r *Runner) newCreateInputSource(ctx context.Context, opts cli.Options, excludeMatcher *archivepath.CompiledPathMatcher, precomputeTotal bool) (createInputSource, error) {
+	if !precomputeTotal {
+		return liveCreateInputSource{
+			opts:           opts,
+			excludeMatcher: excludeMatcher,
+		}, nil
+	}
+
+	plan, err := r.buildCreatePlan(ctx, opts, excludeMatcher)
+	if err != nil {
+		return nil, err
+	}
+	return plannedCreateInputSource{plan: plan}, nil
+}
+
+// visitLocalCreateSource consumes one local create source and accumulates any
+// warnings reported by the caller-supplied entry handler.
+func visitLocalCreateSource(ctx context.Context, source localCreateSource, handle func(record localCreateRecord, info fs.FileInfo) (int, error)) (int, error) {
+	warnings := 0
+	err := source.Visit(ctx, func(record localCreateRecord, info fs.FileInfo) error {
+		w, err := handle(record, info)
+		warnings += w
+		return err
+	})
+	return warnings, err
+}

--- a/packages/engine/create_source.go
+++ b/packages/engine/create_source.go
@@ -12,8 +12,13 @@ import (
 )
 
 // localCreateSource provides one local create workload as normalized archive
-// records paired with the current filesystem metadata used to write them.
+// records paired with filesystem metadata supplied by the implementation.
+// Implementations may either refresh metadata immediately before calling the
+// visitor or reuse metadata obtained during planning or traversal.
 type localCreateSource interface {
+	// Visit invokes visit for each record and its associated filesystem
+	// metadata. Callers must not assume the metadata is freshly re-statted
+	// unless the concrete implementation documents that guarantee.
 	Visit(ctx context.Context, visit func(record localCreateRecord, info fs.FileInfo) error) error
 }
 
@@ -58,8 +63,17 @@ func (s plannedLocalCreateSource) Visit(ctx context.Context, visit func(record l
 
 // createInputSource dispatches create-mode members and exposes any known total
 // payload size for progress reporting.
+// createInputSource abstracts the input used by a create operation.
+//
+// Implementations may represent local content, existing S3-backed content,
+// or a combination of both. Total reports the overall payload size when it
+// can be determined ahead of time. Visit walks the source and dispatches each
+// encountered item to the appropriate handler, returning the number of visited
+// items or the first error encountered.
 type createInputSource interface {
+	// Total returns the total payload size and whether that total is known upfront.
 	Total() (int64, bool)
+	// Visit walks the source and dispatches each item to the appropriate handler.
 	Visit(ctx context.Context, handleS3 func(ref locator.Ref) error, handleLocal func(source localCreateSource) (int, error)) (int, error)
 }
 

--- a/packages/engine/create_tar.go
+++ b/packages/engine/create_tar.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -40,32 +41,20 @@ func (r *Runner) runCreateTar(ctx context.Context, opts cli.Options, archiveRef 
 		return 0, err
 	}
 	excludeMatcher := archivepath.NewCompiledPathMatcher(excludes)
-	plan, err := r.buildCreatePlanIfEnabled(ctx, opts, excludeMatcher, reporter)
+	source, err := r.newCreateInputSource(ctx, opts, excludeMatcher, reporter != nil && reporter.Enabled())
 	if err != nil {
 		return 0, err
 	}
-	if plan != nil {
-		return r.processCreatePlan(
-			ctx,
-			plan,
-			func(ref locator.Ref) error {
-				return r.addS3Member(ctx, tw, ref, opts.Verbose, reporter)
-			},
-			func(entries []localCreateEntry) (int, error) {
-				return r.addLocalEntries(ctx, tw, entries, opts.Verbose, metadataPolicy, reporter)
-			},
-		)
-	}
+	total, totalKnown := source.Total()
+	reporter.SetTotal(total, totalKnown)
 
-	return r.processCreateMembers(
+	return source.Visit(
 		ctx,
-		opts,
-		excludeMatcher,
 		func(ref locator.Ref) error {
 			return r.addS3Member(ctx, tw, ref, opts.Verbose, reporter)
 		},
-		func(member string) (int, error) {
-			return r.addLocalPath(ctx, tw, member, opts.Chdir, excludeMatcher, opts.Verbose, metadataPolicy, reporter)
+		func(source localCreateSource) (int, error) {
+			return r.addLocalTarSource(ctx, tw, source, opts.Verbose, metadataPolicy, reporter)
 		},
 	)
 }
@@ -91,58 +80,19 @@ func (r *Runner) addS3Member(ctx context.Context, tw tarArchiveWriter, ref locat
 	})
 }
 
-// addLocalPath walks one local member path and writes entries into the tar
-// stream, returning any metadata warnings emitted along the way.
-func (r *Runner) addLocalPath(ctx context.Context, tw tarArchiveWriter, member, chdir string, excludeMatcher *archivepath.CompiledPathMatcher, verbose bool, metadataPolicy MetadataPolicy, reporter *archiveprogress.Reporter) (int, error) {
-	warnings := 0
-	err := walkLocalCreateMember(ctx, member, chdir, excludeMatcher, func(entry localCreateEntry) error {
-		w, err := r.writeLocalTarEntry(ctx, tw, entry, verbose, metadataPolicy, reporter)
-		warnings += w
-		return err
+// addLocalTarSource writes one local create source into the tar stream,
+// returning any metadata warnings emitted along the way.
+func (r *Runner) addLocalTarSource(ctx context.Context, tw tarArchiveWriter, source localCreateSource, verbose bool, metadataPolicy MetadataPolicy, reporter *archiveprogress.Reporter) (int, error) {
+	return visitLocalCreateSource(ctx, source, func(record localCreateRecord, info fs.FileInfo) (int, error) {
+		return r.writeLocalTarRecord(ctx, tw, record, info, verbose, metadataPolicy, reporter)
 	})
-	return warnings, err
 }
 
-// collectLocalCreateEntries walks one local member once and returns the
-// normalized archive entries together with their total regular-file size.
-func (r *Runner) collectLocalCreateEntries(ctx context.Context, member, chdir string, excludeMatcher *archivepath.CompiledPathMatcher) ([]localCreateEntry, int64, error) {
-	entries := make([]localCreateEntry, 0)
-	var total int64
-	err := walkLocalCreateMember(ctx, member, chdir, excludeMatcher, func(entry localCreateEntry) error {
-		entries = append(entries, entry)
-		if entry.info.Mode().IsRegular() {
-			total += entry.info.Size()
-		}
-		return nil
-	})
-	return entries, total, err
-}
-
-// addLocalEntries writes a pre-scanned set of local filesystem entries into the
-// tar stream, returning any metadata warnings emitted along the way.
-func (r *Runner) addLocalEntries(ctx context.Context, tw tarArchiveWriter, entries []localCreateEntry, verbose bool, metadataPolicy MetadataPolicy, reporter *archiveprogress.Reporter) (int, error) {
-	warnings := 0
-	for _, entry := range entries {
-		select {
-		case <-ctx.Done():
-			return warnings, ctx.Err()
-		default:
-		}
-		w, err := r.writeLocalTarEntry(ctx, tw, entry, verbose, metadataPolicy, reporter)
-		warnings += w
-		if err != nil {
-			return warnings, err
-		}
-	}
-	return warnings, nil
-}
-
-// writeLocalTarEntry writes one local filesystem entry into the tar stream.
-func (r *Runner) writeLocalTarEntry(ctx context.Context, tw tarArchiveWriter, entry localCreateEntry, verbose bool, metadataPolicy MetadataPolicy, reporter *archiveprogress.Reporter) (int, error) {
-	st := entry.info
+// writeLocalTarRecord writes one local filesystem record into the tar stream.
+func (r *Runner) writeLocalTarRecord(ctx context.Context, tw tarArchiveWriter, record localCreateRecord, st fs.FileInfo, verbose bool, metadataPolicy MetadataPolicy, reporter *archiveprogress.Reporter) (int, error) {
 	linkname := ""
 	if st.Mode()&os.ModeSymlink != 0 {
-		resolvedLink, err := os.Readlink(entry.current)
+		resolvedLink, err := os.Readlink(record.current)
 		if err != nil {
 			return 0, err
 		}
@@ -152,14 +102,14 @@ func (r *Runner) writeLocalTarEntry(ctx context.Context, tw tarArchiveWriter, en
 	if err != nil {
 		return 0, err
 	}
-	hdr.Name = filepath.ToSlash(entry.archiveName)
+	hdr.Name = filepath.ToSlash(record.archiveName)
 	hdr.Format = tar.FormatPAX
 
 	warnings := 0
 	if metadataPolicy.Xattrs || metadataPolicy.ACL {
-		xattrs, acls, err := archive.ReadPathMetadata(entry.current)
+		xattrs, acls, err := archive.ReadPathMetadata(record.current)
 		if err != nil {
-			warnings += r.warnf(reporter, "create: metadata for %s is incomplete: %v", entry.current, err)
+			warnings += r.warnf(reporter, "create: metadata for %s is incomplete: %v", record.current, err)
 		}
 		xattrs, acls = prepareMetadataForArchive(xattrs, acls, metadataPolicy)
 		archive.EncodeXattrToPAX(hdr, xattrs)
@@ -170,7 +120,7 @@ func (r *Runner) writeLocalTarEntry(ctx context.Context, tw tarArchiveWriter, en
 		return warnings, err
 	}
 	if st.Mode().IsRegular() {
-		f, err := os.Open(entry.current)
+		f, err := os.Open(record.current)
 		if err != nil {
 			return warnings, err
 		}

--- a/packages/engine/engine.go
+++ b/packages/engine/engine.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/islishude/gotgz/packages/archivepath"
 	"github.com/islishude/gotgz/packages/archiveprogress"
 	"github.com/islishude/gotgz/packages/archiveutil"
 	"github.com/islishude/gotgz/packages/cli"
@@ -176,42 +175,6 @@ func (r *Runner) runExtract(ctx context.Context, opts cli.Options, reporter *arc
 	default:
 		return 0, fmt.Errorf("cannot determine archive format for %q; consider using -suffix", opts.Archive)
 	}
-}
-
-// processCreateMembers parses create-mode members once and dispatches them by backend kind.
-func (r *Runner) processCreateMembers(ctx context.Context, opts cli.Options, excludeMatcher *archivepath.CompiledPathMatcher, handleS3 func(ref locator.Ref) error, handleLocal func(member string) (int, error)) (int, error) {
-	warnings := 0
-	for _, member := range opts.Members {
-		select {
-		case <-ctx.Done():
-			return warnings, ctx.Err()
-		default:
-		}
-
-		ref, err := locator.ParseMember(member)
-		if err != nil {
-			return warnings, err
-		}
-
-		switch ref.Kind {
-		case locator.KindS3:
-			if archivepath.MatchExcludeWithMatcher(excludeMatcher, ref.Key) {
-				continue
-			}
-			if err := handleS3(ref); err != nil {
-				return warnings, err
-			}
-		case locator.KindLocal:
-			w, err := handleLocal(member)
-			warnings += w
-			if err != nil {
-				return warnings, err
-			}
-		default:
-			return warnings, fmt.Errorf("unsupported member reference %q", member)
-		}
-	}
-	return warnings, nil
 }
 
 // dispatchExtractTarget routes one normalized archive entry to the resolved extract target.

--- a/packages/engine/engine_test.go
+++ b/packages/engine/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -191,26 +192,41 @@ func TestRunReturnsReporterState(t *testing.T) {
 	}
 }
 
-func TestProcessCreateMembers(t *testing.T) {
+func TestLiveCreateInputSourceVisit(t *testing.T) {
 	ctx := context.Background()
-	opts := cli.Options{Members: []string{"src/file.txt", "s3://bucket/object.txt", "s3://bucket/skip.txt"}}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "file.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	source := liveCreateInputSource{
+		opts: cli.Options{
+			Members: []string{"src/file.txt", "s3://bucket/object.txt", "s3://bucket/skip.txt"},
+			Chdir:   root,
+		},
+		excludeMatcher: archivepath.NewCompiledPathMatcher([]string{"skip.txt"}),
+	}
 	var seen []string
 
-	warnings, err := (&Runner{}).processCreateMembers(
+	warnings, err := source.Visit(
 		ctx,
-		opts,
-		archivepath.NewCompiledPathMatcher([]string{"skip.txt"}),
 		func(ref locator.Ref) error {
 			seen = append(seen, "s3:"+ref.Key)
 			return nil
 		},
-		func(member string) (int, error) {
-			seen = append(seen, "local:"+member)
-			return 2, nil
+		func(source localCreateSource) (int, error) {
+			err := source.Visit(ctx, func(record localCreateRecord, _ fs.FileInfo) error {
+				seen = append(seen, "local:"+record.archiveName)
+				return nil
+			})
+			return 2, err
 		},
 	)
 	if err != nil {
-		t.Fatalf("processCreateMembers() error = %v", err)
+		t.Fatalf("Visit() error = %v", err)
 	}
 	if warnings != 2 {
 		t.Fatalf("warnings = %d, want 2", warnings)

--- a/packages/engine/local_create_walk.go
+++ b/packages/engine/local_create_walk.go
@@ -11,15 +11,14 @@ import (
 	"github.com/islishude/gotgz/packages/archivepath"
 )
 
-// localCreateEntry describes one local filesystem entry normalized for archive creation.
-type localCreateEntry struct {
+// localCreateRecord identifies one local filesystem entry normalized for archive creation.
+type localCreateRecord struct {
 	current     string
 	archiveName string
-	info        fs.FileInfo
 }
 
 // walkLocalCreateMember normalizes one local create member and visits all non-excluded entries.
-func walkLocalCreateMember(ctx context.Context, member string, chdir string, excludeMatcher *archivepath.CompiledPathMatcher, visit func(entry localCreateEntry) error) error {
+func walkLocalCreateMember(ctx context.Context, member string, chdir string, excludeMatcher *archivepath.CompiledPathMatcher, visit func(record localCreateRecord, info fs.FileInfo) error) error {
 	basePath := member
 	if chdir != "" {
 		basePath = filepath.Join(chdir, member)
@@ -53,12 +52,26 @@ func walkLocalCreateMember(ctx context.Context, member string, chdir string, exc
 		if err != nil {
 			return err
 		}
-		return visit(localCreateEntry{
+		return visit(localCreateRecord{
 			current:     current,
 			archiveName: archiveName,
-			info:        info,
-		})
+		}, info)
 	})
+}
+
+// collectLocalCreateRecords walks one local member once, returning normalized
+// archive records together with the total regular-file size seen during the scan.
+func collectLocalCreateRecords(ctx context.Context, member string, chdir string, excludeMatcher *archivepath.CompiledPathMatcher) ([]localCreateRecord, int64, error) {
+	records := make([]localCreateRecord, 0)
+	var total int64
+	err := walkLocalCreateMember(ctx, member, chdir, excludeMatcher, func(record localCreateRecord, info fs.FileInfo) error {
+		records = append(records, record)
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return records, total, err
 }
 
 // localCreateBasePrefix returns the fast-path prefix used to derive archive

--- a/packages/engine/local_create_walk_test.go
+++ b/packages/engine/local_create_walk_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,8 +24,8 @@ func TestWalkLocalCreateMember(t *testing.T) {
 	}
 
 	var seen []string
-	err := walkLocalCreateMember(context.Background(), "dir", root, archivepath.NewCompiledPathMatcher([]string{"dir/skipme"}), func(entry localCreateEntry) error {
-		seen = append(seen, entry.archiveName)
+	err := walkLocalCreateMember(context.Background(), "dir", root, archivepath.NewCompiledPathMatcher([]string{"dir/skipme"}), func(record localCreateRecord, _ fs.FileInfo) error {
+		seen = append(seen, record.archiveName)
 		return nil
 	})
 	if err != nil {
@@ -43,8 +44,8 @@ func TestWalkLocalCreateMemberDotMember(t *testing.T) {
 	}
 
 	var seen []string
-	err := walkLocalCreateMember(context.Background(), ".", root, nil, func(entry localCreateEntry) error {
-		seen = append(seen, entry.archiveName)
+	err := walkLocalCreateMember(context.Background(), ".", root, nil, func(record localCreateRecord, _ fs.FileInfo) error {
+		seen = append(seen, record.archiveName)
 		return nil
 	})
 	if err != nil {

--- a/packages/engine/zip.go
+++ b/packages/engine/zip.go
@@ -36,33 +36,20 @@ func (r *Runner) runCreateZip(ctx context.Context, opts cli.Options, archiveRef 
 		return warnings, err
 	}
 	excludeMatcher := archivepath.NewCompiledPathMatcher(excludes)
-	plan, err := r.buildCreatePlanIfEnabled(ctx, opts, excludeMatcher, reporter)
+	source, err := r.newCreateInputSource(ctx, opts, excludeMatcher, reporter != nil && reporter.Enabled())
 	if err != nil {
 		return warnings, err
 	}
-	if plan != nil {
-		createWarnings, err := r.processCreatePlan(
-			ctx,
-			plan,
-			func(ref locator.Ref) error {
-				return r.addS3MemberZip(ctx, zw, ref, opts.Verbose, reporter)
-			},
-			func(entries []localCreateEntry) (int, error) {
-				return r.addLocalEntriesZip(ctx, zw, entries, opts.Verbose, reporter)
-			},
-		)
-		return warnings + createWarnings, err
-	}
+	total, totalKnown := source.Total()
+	reporter.SetTotal(total, totalKnown)
 
-	createWarnings, err := r.processCreateMembers(
+	createWarnings, err := source.Visit(
 		ctx,
-		opts,
-		excludeMatcher,
 		func(ref locator.Ref) error {
 			return r.addS3MemberZip(ctx, zw, ref, opts.Verbose, reporter)
 		},
-		func(member string) (int, error) {
-			return r.addLocalPathZip(ctx, zw, member, opts.Chdir, excludeMatcher, opts.Verbose, reporter)
+		func(source localCreateSource) (int, error) {
+			return r.addLocalZipSource(ctx, zw, source, opts.Verbose, reporter)
 		},
 	)
 	return warnings + createWarnings, err

--- a/packages/engine/zip_members.go
+++ b/packages/engine/zip_members.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/islishude/gotgz/packages/archivepath"
 	"github.com/islishude/gotgz/packages/archiveprogress"
 	"github.com/islishude/gotgz/packages/archiveutil"
 	"github.com/islishude/gotgz/packages/locator"
@@ -37,40 +37,16 @@ func (r *Runner) addS3MemberZip(ctx context.Context, zw zipArchiveWriter, ref lo
 	})
 }
 
-// addLocalPathZip walks a local member and writes entries into the zip archive.
-func (r *Runner) addLocalPathZip(ctx context.Context, zw zipArchiveWriter, member, chdir string, excludeMatcher *archivepath.CompiledPathMatcher, verbose bool, reporter *archiveprogress.Reporter) (int, error) {
-	warnings := 0
-	err := walkLocalCreateMember(ctx, member, chdir, excludeMatcher, func(entry localCreateEntry) error {
-		w, err := r.writeLocalZipEntry(ctx, zw, entry, verbose, reporter)
-		warnings += w
-		return err
+// addLocalZipSource writes one local create source into the zip archive.
+func (r *Runner) addLocalZipSource(ctx context.Context, zw zipArchiveWriter, source localCreateSource, verbose bool, reporter *archiveprogress.Reporter) (int, error) {
+	return visitLocalCreateSource(ctx, source, func(record localCreateRecord, info fs.FileInfo) (int, error) {
+		return r.writeLocalZipRecord(ctx, zw, record, info, verbose, reporter)
 	})
-	return warnings, err
 }
 
-// addLocalEntriesZip writes a pre-scanned set of local filesystem entries into
-// the zip archive.
-func (r *Runner) addLocalEntriesZip(ctx context.Context, zw zipArchiveWriter, entries []localCreateEntry, verbose bool, reporter *archiveprogress.Reporter) (int, error) {
-	warnings := 0
-	for _, entry := range entries {
-		select {
-		case <-ctx.Done():
-			return warnings, ctx.Err()
-		default:
-		}
-		w, err := r.writeLocalZipEntry(ctx, zw, entry, verbose, reporter)
-		warnings += w
-		if err != nil {
-			return warnings, err
-		}
-	}
-	return warnings, nil
-}
-
-// writeLocalZipEntry writes one local filesystem entry into the zip archive.
-func (r *Runner) writeLocalZipEntry(ctx context.Context, zw zipArchiveWriter, entry localCreateEntry, verbose bool, reporter *archiveprogress.Reporter) (int, error) {
-	st := entry.info
-	entryName := filepath.ToSlash(entry.archiveName)
+// writeLocalZipRecord writes one local filesystem record into the zip archive.
+func (r *Runner) writeLocalZipRecord(ctx context.Context, zw zipArchiveWriter, record localCreateRecord, st fs.FileInfo, verbose bool, reporter *archiveprogress.Reporter) (int, error) {
+	entryName := filepath.ToSlash(record.archiveName)
 
 	hdr, err := zip.FileInfoHeader(st)
 	if err != nil {
@@ -97,7 +73,7 @@ func (r *Runner) writeLocalZipEntry(ctx context.Context, zw zipArchiveWriter, en
 	switch {
 	case st.IsDir():
 	case st.Mode()&os.ModeSymlink != 0:
-		linkTarget, err := os.Readlink(entry.current)
+		linkTarget, err := os.Readlink(record.current)
 		if err != nil {
 			return 0, err
 		}
@@ -105,7 +81,7 @@ func (r *Runner) writeLocalZipEntry(ctx context.Context, zw zipArchiveWriter, en
 			return 0, err
 		}
 	case st.Mode().IsRegular():
-		f, err := os.Open(entry.current)
+		f, err := os.Open(record.current)
 		if err != nil {
 			return 0, err
 		}
@@ -121,7 +97,7 @@ func (r *Runner) writeLocalZipEntry(ctx context.Context, zw zipArchiveWriter, en
 		if err := zw.FinishEntry(); err != nil {
 			return 0, err
 		}
-		return r.warnf(reporter, "zip create: unsupported local member type %s for %s; skipping payload", st.Mode().String(), entry.current), nil
+		return r.warnf(reporter, "zip create: unsupported local member type %s for %s; skipping payload", st.Mode().String(), record.current), nil
 	}
 	if err := zw.FinishEntry(); err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary

This refactor unifies create-mode input handling behind shared source abstractions and removes the split between live member walking and precomputed plan replay in the tar/zip create paths.

## What Changed

- Added `createInputSource` and `localCreateSource` to represent create-mode inputs uniformly
- Made both tar and zip create flows consume the same source-based traversal API
- Replaced cached local `fs.FileInfo` snapshots in the create plan with lightweight `localCreateRecord` entries
- Refreshed local file metadata with `os.Lstat` at write time when replaying planned local entries
- Removed the old dual-path branching that separately handled `processCreatePlan` and `processCreateMembers`

## Why

Previously, create mode used two different execution paths:

- a precomputed plan path when progress totals were needed
- a direct walk path when they were not

That worked, but it duplicated control flow in both tar and zip creation.

It also meant the plan cached `fs.FileInfo` values from scan time. If a local file's metadata changed after planning but before archive writing, the archive header could be generated from stale metadata while the payload was read from the current file.

This change keeps the existing performance characteristics while making the flow cleaner and more consistent:

- progress-enabled runs can still precompute totals and avoid a second directory walk
- tar and zip now share the same source-driven traversal model
- planned local entries use fresh metadata at write time instead of stale scan-time snapshots

## Behavior Notes

- Files discovered during plan construction are still fixed by that plan; newly added files after planning are not included
- Local metadata is now refreshed at write time, so mode/type changes after planning are reflected in tar/zip headers

## Testing

- `go test ./packages/engine`
