### PR TITLE
feat: implement concurrent S3 extraction for zip and tar archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ gotgz -cvzf "s3://my-bucket/backups/archive.tgz?env=prod&owner=platform" dir/
 Use `--s3-cache-control` to set the S3 `Cache-Control` header for archive uploads (`-f s3://...`) and extract targets (`-C s3://...`) without URL-encoding.
 Use repeatable `--s3-tag key=value` flags to add S3 object tags for archive uploads and extract targets.
 
+When extracting archives to S3 (`-x -C s3://...`), `gotgz` can upload multiple extracted objects in parallel. ZIP extracts use object-level workers directly; TAR extracts stage smaller regular files to temporary storage before uploading so archive read order is preserved.
+Set `GOTGZ_S3_EXTRACT_WORKERS` to control object-level parallelism, `GOTGZ_S3_EXTRACT_STAGING_BYTES` to cap TAR staging bytes, and `GOTGZ_S3_EXTRACT_STAGING_DIR` to choose the temporary directory. When extracting remote ZIP archives to S3 with more than one worker, `gotgz` stages the ZIP locally first and still applies `GOTGZ_ZIP_STAGING_LIMIT_BYTES`.
+
 ### Required S3 permissions
 
 `gotgz` only uses a small set of S3 data-plane permissions. The exact IAM policy depends on which S3 features you use:
@@ -292,6 +295,9 @@ gotgz -cvf out.tar --no-progress dir/   # hides live updates but still prints "c
 | `GOTGZ_S3_SSE_KMS_KEY_ID`       | KMS key ID for SSE-KMS encryption                                                     |              |
 | `GOTGZ_S3_PART_SIZE_MB`         | S3 transfer part size in MB for multipart uploads and transfer-manager downloads      | `16`         |
 | `GOTGZ_S3_CONCURRENCY`          | S3 transfer concurrency for multipart uploads and transfer-manager downloads           | `4`          |
+| `GOTGZ_S3_EXTRACT_WORKERS`      | Object-level worker count for archive extraction to S3 (`-x -C s3://...`)            | `8`          |
+| `GOTGZ_S3_EXTRACT_STAGING_BYTES`| Max total bytes TAR extraction may stage locally before S3 upload                     | `536870912`  |
+| `GOTGZ_S3_EXTRACT_STAGING_DIR`  | Temp directory used for staged S3 extract payloads and remote ZIP-to-S3 staging       | system temp  |
 | `GOTGZ_S3_MAX_RETRIES`          | Maximum retry attempts for S3 operations                                              |              |
 | `GOTGZ_S3_USE_PATH_STYLE`       | Use path-style S3 addressing (for RustStack/MinIO)                                    | `false`      |
 | `GOTGZ_ZIP_STAGING_LIMIT_BYTES` | Max bytes spooled for non-local ZIP list/extract staging (`-`, `s3://`, `http(s)://`) | `1073741824` |

--- a/packages/engine/engine.go
+++ b/packages/engine/engine.go
@@ -26,9 +26,10 @@ type PermissionPolicy = cli.PermissionPolicy
 type MetadataPolicy = cli.MetadataPolicy
 
 type Runner struct {
-	storage *storageRouter
-	stderr  io.Writer
-	stdout  io.Writer
+	storage   *storageRouter
+	stderr    io.Writer
+	stdout    io.Writer
+	s3Extract s3ExtractConfig
 }
 
 // RunResult summarizes one completed CLI operation together with progress metadata.
@@ -58,16 +59,24 @@ func New(ctx context.Context, stdout io.Writer, stderr io.Writer) (*Runner, erro
 		httpstore.New(),
 		stdout,
 		stderr,
+		withS3ExtractConfig(newS3ExtractConfigFromStoreSettings(s3s.Settings())),
 	), nil
 }
 
 // newRunner wires a Runner from injected storage backends.
-func newRunner(local localArchiveStore, s3 s3ArchiveStore, http httpArchiveStore, stdout io.Writer, stderr io.Writer) *Runner {
-	return &Runner{
-		storage: newStorageRouter(local, s3, http),
-		stdout:  stdout,
-		stderr:  stderr,
+func newRunner(local localArchiveStore, s3 s3ArchiveStore, http httpArchiveStore, stdout io.Writer, stderr io.Writer, opts ...runnerOption) *Runner {
+	r := &Runner{
+		storage:   newStorageRouter(local, s3, http),
+		stdout:    stdout,
+		stderr:    stderr,
+		s3Extract: defaultS3ExtractConfig(),
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
+	}
+	return r
 }
 
 // Run executes one CLI mode and maps warnings/errors to a process exit code.

--- a/packages/engine/extract_tar.go
+++ b/packages/engine/extract_tar.go
@@ -75,6 +75,35 @@ func (r *Runner) runExtractTarReader(ctx context.Context, opts cli.Options, repo
 		safetyCache = archivepath.NewPathSafetyCache()
 	}
 
+	if r.shouldUseConcurrentS3Extract(parsedTarget) {
+		reporter.SetTotal(0, false)
+		return r.extractTarEntriesToS3Concurrent(ctx, parsedTarget, func(pipeline *s3ExtractPipeline, budget *s3ExtractStagingBudget) (int, error) {
+			return r.scanTarArchiveFromReader(ctx, opts, reporter, info, opts.Archive, ar, func(hdr *tar.Header, tr *tar.Reader) (int, error) {
+				if archivepath.ShouldSkipMemberWithMatcher(memberMatcher, hdr.Name) {
+					if _, err := archiveutil.CopyWithContext(ctx, io.Discard, tr); err != nil {
+						return 0, err
+					}
+					return 0, nil
+				}
+				extractName, ok := archivepath.StripPathComponents(hdr.Name, opts.StripComponents)
+				if !ok {
+					if _, err := archiveutil.CopyWithContext(ctx, io.Discard, io.LimitReader(tr, hdr.Size)); err != nil {
+						return 0, err
+					}
+					return 0, nil
+				}
+				effectiveHdr := *hdr
+				effectiveHdr.Name = extractName
+				if opts.Verbose {
+					reporter.BeforeExternalLineOutput()
+					_, _ = fmt.Fprintln(r.stdout, effectiveHdr.Name)
+					reporter.AfterExternalLineOutput()
+				}
+				return r.extractToS3Concurrent(ctx, parsedTarget, &effectiveHdr, tr, reporter, pipeline, budget)
+			})
+		})
+	}
+
 	return r.scanTarArchiveFromReader(ctx, opts, reporter, info, opts.Archive, ar, func(hdr *tar.Header, tr *tar.Reader) (int, error) {
 		if archivepath.ShouldSkipMemberWithMatcher(memberMatcher, hdr.Name) {
 			if _, err := archiveutil.CopyWithContext(ctx, io.Discard, tr); err != nil {

--- a/packages/engine/s3_extract_concurrent_test.go
+++ b/packages/engine/s3_extract_concurrent_test.go
@@ -1,0 +1,426 @@
+package engine
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/islishude/gotgz/packages/archivepath"
+	"github.com/islishude/gotgz/packages/archiveprogress"
+	"github.com/islishude/gotgz/packages/cli"
+	"github.com/islishude/gotgz/packages/locator"
+)
+
+func TestWithConcurrentS3ZipReaderStagesRemoteArchive(t *testing.T) {
+	payload := orderedZipArchiveBytes(t, []zipTestEntry{{name: "file.txt", body: "payload"}})
+	stream := &trackingReadCloser{Reader: bytes.NewReader(payload)}
+	runner := newRunner(
+		nil,
+		fakeS3ZipArchiveStore{
+			openRange: func(_ context.Context, _ locator.Ref, _, _ int64) (io.ReadCloser, error) {
+				t.Fatal("remote ranges should not be used for concurrent S3 zip extract")
+				return nil, nil
+			},
+		},
+		nil,
+		io.Discard,
+		io.Discard,
+		withS3ExtractConfig(s3ExtractConfig{
+			workers:      2,
+			stagingBytes: 1024,
+			stagingDir:   t.TempDir(),
+		}),
+	)
+
+	warnings, err := runner.withConcurrentS3ZipReader(
+		context.Background(),
+		locator.Ref{Kind: locator.KindS3, Raw: "s3://bucket/archive.zip", Bucket: "bucket", Key: "archive.zip"},
+		stream,
+		archiveReaderInfo{Size: int64(len(payload)), SizeKnown: true},
+		nil,
+		func(zr *zip.Reader) (int, error) {
+			if len(zr.File) != 1 || zr.File[0].Name != "file.txt" {
+				t.Fatalf("zip files = %+v", zr.File)
+			}
+			return 0, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("withConcurrentS3ZipReader() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("warnings = %d, want 0", warnings)
+	}
+	if stream.readCalls == 0 {
+		t.Fatal("expected staged zip reader to consume the original stream")
+	}
+}
+
+func TestExtractZipEntriesToS3ConcurrentRunsUploadsInParallel(t *testing.T) {
+	payload := orderedZipArchiveBytes(t, []zipTestEntry{
+		{name: "a.txt", body: "alpha"},
+		{name: "b.txt", body: "bravo"},
+	})
+	zr, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		t.Fatalf("zip.NewReader() error = %v", err)
+	}
+
+	var (
+		mu      sync.Mutex
+		current int
+		maxSeen int
+		bodies  = map[string]string{}
+	)
+	twoStarted := make(chan struct{})
+	release := make(chan struct{})
+
+	var stdout bytes.Buffer
+	runner := newRunner(
+		nil,
+		fakeS3ArchiveStore{
+			uploadStream: func(_ context.Context, ref locator.Ref, body io.Reader, _ map[string]string) error {
+				mu.Lock()
+				current++
+				if current > maxSeen {
+					maxSeen = current
+				}
+				if current == 2 {
+					select {
+					case <-twoStarted:
+					default:
+						close(twoStarted)
+					}
+				}
+				mu.Unlock()
+
+				<-release
+				payload, err := io.ReadAll(body)
+				if err != nil {
+					return err
+				}
+
+				mu.Lock()
+				bodies[ref.Key] = string(payload)
+				current--
+				mu.Unlock()
+				return nil
+			},
+		},
+		nil,
+		&stdout,
+		io.Discard,
+		withS3ExtractConfig(s3ExtractConfig{
+			workers:      2,
+			stagingBytes: 1024,
+			stagingDir:   t.TempDir(),
+		}),
+	)
+
+	reporter := archiveprogress.NewReporter(io.Discard, cli.ProgressNever, 0, false, time.Now(), false)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runner.extractZipEntriesToS3Concurrent(
+			context.Background(),
+			zr,
+			cli.Options{Verbose: true},
+			reporter,
+			locator.Ref{Kind: locator.KindS3, Bucket: "bucket", Key: "prefix"},
+			archivepath.NewCompiledPathMatcher(nil),
+		)
+		errCh <- err
+	}()
+
+	select {
+	case <-twoStarted:
+	case <-time.After(time.Second):
+		t.Fatal("zip uploads did not overlap")
+	}
+	close(release)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("extractZipEntriesToS3Concurrent() error = %v", err)
+	}
+
+	mu.Lock()
+	gotMax := maxSeen
+	gotBodies := map[string]string{
+		"prefix/a.txt": bodies["prefix/a.txt"],
+		"prefix/b.txt": bodies["prefix/b.txt"],
+	}
+	mu.Unlock()
+
+	if gotMax < 2 {
+		t.Fatalf("max concurrent uploads = %d, want at least 2", gotMax)
+	}
+	if gotBodies["prefix/a.txt"] != "alpha" || gotBodies["prefix/b.txt"] != "bravo" {
+		t.Fatalf("uploaded bodies = %#v", gotBodies)
+	}
+	if stdout.String() != "a.txt\nb.txt\n" {
+		t.Fatalf("stdout = %q, want archive-order verbose output", stdout.String())
+	}
+}
+
+func TestExtractTarEntriesToS3ConcurrentStagesSmallFiles(t *testing.T) {
+	stagingDir := t.TempDir()
+	tr := newTarReaderFromEntries(t, []tarEntry{
+		{hdr: newTarHeader("a.txt", 5, 0o644), body: "alpha"},
+		{hdr: newTarHeader("b.txt", 5, 0o644), body: "bravo"},
+	})
+
+	var (
+		mu      sync.Mutex
+		current int
+		maxSeen int
+		bodies  = map[string]string{}
+	)
+	twoStarted := make(chan struct{})
+	release := make(chan struct{})
+
+	runner := newRunner(
+		nil,
+		fakeS3ArchiveStore{
+			uploadStream: func(_ context.Context, ref locator.Ref, body io.Reader, _ map[string]string) error {
+				if _, ok := body.(*os.File); !ok {
+					t.Fatalf("body type = %T, want *os.File for staged upload", body)
+				}
+
+				mu.Lock()
+				current++
+				if current > maxSeen {
+					maxSeen = current
+				}
+				if current == 2 {
+					select {
+					case <-twoStarted:
+					default:
+						close(twoStarted)
+					}
+				}
+				mu.Unlock()
+
+				<-release
+				payload, err := io.ReadAll(body)
+				if err != nil {
+					return err
+				}
+
+				mu.Lock()
+				bodies[ref.Key] = string(payload)
+				current--
+				mu.Unlock()
+				return nil
+			},
+		},
+		nil,
+		io.Discard,
+		io.Discard,
+		withS3ExtractConfig(s3ExtractConfig{
+			workers:      2,
+			stagingBytes: 16,
+			stagingDir:   stagingDir,
+		}),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runner.extractTarEntriesToS3Concurrent(context.Background(), locator.Ref{Kind: locator.KindS3, Bucket: "bucket", Key: "prefix"}, func(pipeline *s3ExtractPipeline, budget *s3ExtractStagingBudget) (int, error) {
+			warnings := 0
+			for {
+				hdr, err := tr.Next()
+				if errors.Is(err, io.EOF) {
+					return warnings, nil
+				}
+				if err != nil {
+					return warnings, err
+				}
+				w, err := runner.extractToS3Concurrent(context.Background(), locator.Ref{Kind: locator.KindS3, Bucket: "bucket", Key: "prefix"}, hdr, tr, nil, pipeline, budget)
+				warnings += w
+				if err != nil {
+					return warnings, err
+				}
+			}
+		})
+		errCh <- err
+	}()
+
+	select {
+	case <-twoStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tar uploads did not overlap")
+	}
+	close(release)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("extractTarEntriesToS3Concurrent() error = %v", err)
+	}
+
+	mu.Lock()
+	gotMax := maxSeen
+	gotBodies := map[string]string{
+		"prefix/a.txt": bodies["prefix/a.txt"],
+		"prefix/b.txt": bodies["prefix/b.txt"],
+	}
+	mu.Unlock()
+
+	if gotMax < 2 {
+		t.Fatalf("max concurrent uploads = %d, want at least 2", gotMax)
+	}
+	if gotBodies["prefix/a.txt"] != "alpha" || gotBodies["prefix/b.txt"] != "bravo" {
+		t.Fatalf("uploaded bodies = %#v", gotBodies)
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatalf("os.ReadDir(%q) error = %v", stagingDir, err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging dir entries = %d, want 0", len(entries))
+	}
+}
+
+func TestExtractToS3ConcurrentFallsBackToInlineUploadForLargeTarEntry(t *testing.T) {
+	stagingDir := t.TempDir()
+	tr := newTarReaderFromEntries(t, []tarEntry{{hdr: newTarHeader("large.txt", 8, 0o644), body: "payload!"}})
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("tr.Next() error = %v", err)
+	}
+
+	var sawInline bool
+	runner := newRunner(
+		nil,
+		fakeS3ArchiveStore{
+			uploadStream: func(_ context.Context, ref locator.Ref, body io.Reader, _ map[string]string) error {
+				if _, ok := body.(*os.File); ok {
+					t.Fatalf("body type = %T, want inline stream", body)
+				}
+				sawInline = true
+				payload, err := io.ReadAll(body)
+				if err != nil {
+					return err
+				}
+				if string(payload) != "payload!" {
+					t.Fatalf("payload = %q, want %q", string(payload), "payload!")
+				}
+				if ref.Key != "prefix/large.txt" {
+					t.Fatalf("ref.Key = %q, want %q", ref.Key, "prefix/large.txt")
+				}
+				return nil
+			},
+		},
+		nil,
+		io.Discard,
+		io.Discard,
+		withS3ExtractConfig(s3ExtractConfig{
+			workers:      2,
+			stagingBytes: 4,
+			stagingDir:   stagingDir,
+		}),
+	)
+
+	pipeline := newS3ExtractPipeline(context.Background(), runner.s3Extract.workers)
+	budget := newS3ExtractStagingBudget(runner.s3Extract.stagingBytes)
+	_, err = runner.extractToS3Concurrent(context.Background(), locator.Ref{Kind: locator.KindS3, Bucket: "bucket", Key: "prefix"}, hdr, tr, nil, pipeline, budget)
+	if err != nil {
+		t.Fatalf("extractToS3Concurrent() error = %v", err)
+	}
+	if err := pipeline.Wait(); err != nil {
+		t.Fatalf("pipeline.Wait() error = %v", err)
+	}
+	if !sawInline {
+		t.Fatal("expected inline upload for oversized tar entry")
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatalf("os.ReadDir(%q) error = %v", stagingDir, err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging dir entries = %d, want 0", len(entries))
+	}
+}
+
+func TestExtractToS3ConcurrentReleasesBudgetAfterUploadError(t *testing.T) {
+	stagingDir := t.TempDir()
+	tr := newTarReaderFromEntries(t, []tarEntry{{hdr: newTarHeader("fail.txt", 4, 0o644), body: "boom"}})
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("tr.Next() error = %v", err)
+	}
+
+	wantErr := errors.New("upload failed")
+	runner := newRunner(
+		nil,
+		fakeS3ArchiveStore{
+			uploadStream: func(_ context.Context, _ locator.Ref, body io.Reader, _ map[string]string) error {
+				if _, ok := body.(*os.File); !ok {
+					t.Fatalf("body type = %T, want *os.File for staged upload", body)
+				}
+				_, _ = io.ReadAll(body)
+				return wantErr
+			},
+		},
+		nil,
+		io.Discard,
+		io.Discard,
+		withS3ExtractConfig(s3ExtractConfig{
+			workers:      2,
+			stagingBytes: 4,
+			stagingDir:   stagingDir,
+		}),
+	)
+
+	pipeline := newS3ExtractPipeline(context.Background(), runner.s3Extract.workers)
+	budget := newS3ExtractStagingBudget(runner.s3Extract.stagingBytes)
+	_, err = runner.extractToS3Concurrent(context.Background(), locator.Ref{Kind: locator.KindS3, Bucket: "bucket", Key: "prefix"}, hdr, tr, nil, pipeline, budget)
+	if err != nil {
+		t.Fatalf("extractToS3Concurrent() error = %v", err)
+	}
+	if err := pipeline.Wait(); !errors.Is(err, wantErr) {
+		t.Fatalf("pipeline.Wait() error = %v, want %v", err, wantErr)
+	}
+
+	acquireCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := budget.Acquire(acquireCtx, 4); err != nil {
+		t.Fatalf("budget.Acquire() error = %v", err)
+	}
+	budget.Release(4)
+
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatalf("os.ReadDir(%q) error = %v", stagingDir, err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging dir entries = %d, want 0", len(entries))
+	}
+}
+
+type zipTestEntry struct {
+	name string
+	body string
+}
+
+func orderedZipArchiveBytes(t *testing.T, entries []zipTestEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, entry := range entries {
+		w, err := zw.Create(entry.name)
+		if err != nil {
+			t.Fatalf("zw.Create(%q) error = %v", entry.name, err)
+		}
+		if _, err := io.WriteString(w, entry.body); err != nil {
+			t.Fatalf("io.WriteString(%q) error = %v", entry.name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zw.Close() error = %v", err)
+	}
+	return buf.Bytes()
+}

--- a/packages/engine/s3_extract_config.go
+++ b/packages/engine/s3_extract_config.go
@@ -1,0 +1,55 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+
+	s3store "github.com/islishude/gotgz/packages/storage/s3"
+)
+
+const (
+	defaultS3ExtractWorkers      = 1
+	defaultS3ExtractStagingBytes = 512 << 20
+)
+
+// s3ExtractConfig controls archive->S3 extraction concurrency and staging.
+type s3ExtractConfig struct {
+	workers      int
+	stagingBytes int64
+	stagingDir   string
+}
+
+// runnerOption customizes one Runner during construction.
+type runnerOption func(*Runner)
+
+// withS3ExtractConfig applies S3 extract concurrency settings to one Runner.
+func withS3ExtractConfig(cfg s3ExtractConfig) runnerOption {
+	return func(r *Runner) {
+		r.s3Extract = cfg
+	}
+}
+
+// defaultS3ExtractConfig returns conservative defaults used by unit-test helpers.
+func defaultS3ExtractConfig() s3ExtractConfig {
+	return s3ExtractConfig{
+		workers:      defaultS3ExtractWorkers,
+		stagingBytes: defaultS3ExtractStagingBytes,
+		stagingDir:   filepath.Clean(os.TempDir()),
+	}
+}
+
+// newS3ExtractConfigFromStoreSettings maps storage-level env config onto engine behavior.
+func newS3ExtractConfigFromStoreSettings(settings s3store.Settings) s3ExtractConfig {
+	cfg := defaultS3ExtractConfig()
+	cfg.workers = settings.ExtractWorkers
+	if cfg.workers < 1 {
+		cfg.workers = defaultS3ExtractWorkers
+	}
+	if settings.ExtractStagingBytes > 0 {
+		cfg.stagingBytes = settings.ExtractStagingBytes
+	}
+	if settings.ExtractStagingDir != "" {
+		cfg.stagingDir = settings.ExtractStagingDir
+	}
+	return cfg
+}

--- a/packages/engine/s3_extract_pipeline.go
+++ b/packages/engine/s3_extract_pipeline.go
@@ -1,0 +1,266 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/islishude/gotgz/packages/archiveutil"
+)
+
+// s3ExtractTask represents one upload job scheduled by the concurrent extract pipeline.
+type s3ExtractTask func(ctx context.Context) error
+
+// s3ExtractPipeline limits object-level upload concurrency and cancels peer work
+// after the first failure.
+type s3ExtractPipeline struct {
+	parent context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	tasks chan s3ExtractTask
+
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+
+	errMu sync.Mutex
+	err   error
+}
+
+// newS3ExtractPipeline creates one worker pool for archive->S3 extract tasks.
+func newS3ExtractPipeline(parent context.Context, workers int) *s3ExtractPipeline {
+	if workers < 1 {
+		workers = 1
+	}
+	ctx, cancel := context.WithCancel(parent)
+	p := &s3ExtractPipeline{
+		parent: parent,
+		ctx:    ctx,
+		cancel: cancel,
+		tasks:  make(chan s3ExtractTask),
+	}
+	p.wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer p.wg.Done()
+			for task := range p.tasks {
+				if task == nil {
+					continue
+				}
+				if err := task(p.ctx); err != nil {
+					p.storeError(err)
+				}
+			}
+		}()
+	}
+	return p
+}
+
+// Submit queues one task or returns promptly when the pipeline has been canceled.
+func (p *s3ExtractPipeline) Submit(task s3ExtractTask) error {
+	if task == nil {
+		return nil
+	}
+	select {
+	case <-p.ctx.Done():
+		return p.resultError()
+	case p.tasks <- task:
+		return nil
+	}
+}
+
+// Wait closes the task queue, waits for all workers, and returns the first error.
+func (p *s3ExtractPipeline) Wait() error {
+	if p == nil {
+		return nil
+	}
+	p.closeOnce.Do(func() {
+		close(p.tasks)
+	})
+	p.wg.Wait()
+	p.cancel()
+	return p.resultError()
+}
+
+// Context exposes the cancellation context shared by all concurrent extract work.
+func (p *s3ExtractPipeline) Context() context.Context {
+	if p == nil {
+		return nil
+	}
+	return p.ctx
+}
+
+// resultError reports the first task error, otherwise the parent context error.
+func (p *s3ExtractPipeline) resultError() error {
+	if p == nil {
+		return nil
+	}
+	p.errMu.Lock()
+	err := p.err
+	p.errMu.Unlock()
+	if err != nil {
+		return err
+	}
+	if p.parent != nil {
+		return p.parent.Err()
+	}
+	return nil
+}
+
+// storeError records the first task error and cancels the worker context.
+func (p *s3ExtractPipeline) storeError(err error) {
+	if err == nil {
+		return
+	}
+	p.errMu.Lock()
+	if p.err == nil {
+		p.err = err
+		p.cancel()
+	}
+	p.errMu.Unlock()
+}
+
+// s3ExtractStagingBudget bounds the total bytes staged on disk for tar uploads.
+type s3ExtractStagingBudget struct {
+	total int64
+
+	mu     sync.Mutex
+	used   int64
+	notify chan struct{}
+}
+
+// newS3ExtractStagingBudget returns one staging budget manager.
+func newS3ExtractStagingBudget(total int64) *s3ExtractStagingBudget {
+	return &s3ExtractStagingBudget{
+		total:  total,
+		notify: make(chan struct{}),
+	}
+}
+
+// Fits reports whether a single payload can ever fit within the staging budget.
+func (b *s3ExtractStagingBudget) Fits(n int64) bool {
+	return b != nil && n >= 0 && n <= b.total
+}
+
+// Acquire blocks until the requested staging budget is available or ctx ends.
+func (b *s3ExtractStagingBudget) Acquire(ctx context.Context, n int64) error {
+	if b == nil || n <= 0 {
+		return nil
+	}
+	for {
+		b.mu.Lock()
+		if b.used+n <= b.total {
+			b.used += n
+			b.mu.Unlock()
+			return nil
+		}
+		notify := b.notify
+		b.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-notify:
+		}
+	}
+}
+
+// Release returns previously acquired staging bytes to the shared budget.
+func (b *s3ExtractStagingBudget) Release(n int64) {
+	if b == nil || n <= 0 {
+		return
+	}
+	b.mu.Lock()
+	b.used -= n
+	if b.used < 0 {
+		b.used = 0
+	}
+	close(b.notify)
+	b.notify = make(chan struct{})
+	b.mu.Unlock()
+}
+
+// stageReaderToTempPath copies reader into a temp file and returns the file path.
+func stageReaderToTempPath(ctx context.Context, dir string, pattern string, reader io.Reader) (string, error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+
+	path := tmp.Name()
+	if _, err := archiveutil.CopyWithContext(ctx, tmp, reader); err != nil {
+		closeErr := tmp.Close()
+		_ = os.Remove(path)
+		if closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			return "", errors.Join(err, closeErr)
+		}
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
+// stageReaderToTempFileLimit copies reader into a temp file while enforcing an optional limit.
+func stageReaderToTempFileLimit(ctx context.Context, dir string, pattern string, reader io.Reader, limit int64) (*os.File, int64, error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, 0, err
+	}
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := archiveutil.CopyWithContextLimit(ctx, tmp, reader, limit); err != nil {
+		path := tmp.Name()
+		closeErr := tmp.Close()
+		_ = os.Remove(path)
+		if closeErr != nil && !errors.Is(closeErr, os.ErrClosed) {
+			return nil, 0, errors.Join(err, closeErr)
+		}
+		return nil, 0, err
+	}
+	st, err := tmp.Stat()
+	if err != nil {
+		path := tmp.Name()
+		_ = tmp.Close()
+		_ = os.Remove(path)
+		return nil, 0, err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		path := tmp.Name()
+		_ = tmp.Close()
+		_ = os.Remove(path)
+		return nil, 0, err
+	}
+	return tmp, st.Size(), nil
+}
+
+// cleanupTempFile closes and removes one staged file.
+func cleanupTempFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	path := file.Name()
+	closeErr := file.Close()
+	removeErr := os.Remove(path)
+	return errors.Join(closeErr, removeErr)
+}
+
+// openStagedFileReader opens one staged file for upload reads.
+func openStagedFileReader(path string) (*os.File, error) {
+	return os.Open(filepath.Clean(path))
+}

--- a/packages/engine/s3_extract_tar.go
+++ b/packages/engine/s3_extract_tar.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/islishude/gotgz/packages/archive"
+	"github.com/islishude/gotgz/packages/archiveprogress"
+	"github.com/islishude/gotgz/packages/archiveutil"
+	"github.com/islishude/gotgz/packages/locator"
+)
+
+// extractTarEntriesToS3Concurrent creates one bounded worker pool for tar->S3 uploads.
+func (r *Runner) extractTarEntriesToS3Concurrent(ctx context.Context, target locator.Ref, scan func(pipeline *s3ExtractPipeline, budget *s3ExtractStagingBudget) (int, error)) (int, error) {
+	pipeline := newS3ExtractPipeline(ctx, r.s3Extract.workers)
+	budget := newS3ExtractStagingBudget(r.s3Extract.stagingBytes)
+	warnings, err := scan(pipeline, budget)
+	waitErr := pipeline.Wait()
+	if err != nil {
+		return warnings, err
+	}
+	return warnings, waitErr
+}
+
+// extractToS3Concurrent uploads one tar entry with staging when it improves throughput.
+func (r *Runner) extractToS3Concurrent(ctx context.Context, target locator.Ref, hdr *tar.Header, tr *tar.Reader, reporter *archiveprogress.Reporter, pipeline *s3ExtractPipeline, budget *s3ExtractStagingBudget) (int, error) {
+	warnings := 0
+	name := strings.TrimPrefix(hdr.Name, "./")
+	if name == "" {
+		if hdr.Size > 0 {
+			if _, err := archiveutil.CopyWithContext(ctx, io.Discard, io.LimitReader(tr, hdr.Size)); err != nil {
+				return warnings, err
+			}
+		}
+		return warnings, nil
+	}
+
+	meta, ok := archive.HeaderToS3Metadata(hdr)
+	meta = archiveutil.MergeMetadata(target.Metadata, meta)
+	if !ok {
+		warnings += r.warnf(reporter, "metadata exceeds S3 metadata limit for %s", hdr.Name)
+	}
+
+	switch hdr.Typeflag {
+	case tar.TypeReg:
+		return warnings, r.extractRegularTarToS3Concurrent(ctx, target, name, hdr.Size, io.LimitReader(tr, hdr.Size), meta, pipeline, budget)
+	case tar.TypeDir:
+		if _, err := archiveutil.CopyWithContext(ctx, io.Discard, io.LimitReader(tr, hdr.Size)); err != nil {
+			return warnings, err
+		}
+		return warnings, nil
+	default:
+		meta["gotgz-type"] = strconv.Itoa(int(hdr.Typeflag))
+		return warnings, r.uploadToS3Target(ctx, target, name, strings.NewReader(""), meta)
+	}
+}
+
+// extractRegularTarToS3Concurrent stages smaller tar entries before scheduling uploads.
+func (r *Runner) extractRegularTarToS3Concurrent(ctx context.Context, target locator.Ref, name string, size int64, body io.Reader, meta map[string]string, pipeline *s3ExtractPipeline, budget *s3ExtractStagingBudget) error {
+	if size == 0 {
+		return pipeline.Submit(func(ctx context.Context) error {
+			return r.uploadToS3Target(ctx, target, name, strings.NewReader(""), meta)
+		})
+	}
+	if !budget.Fits(size) {
+		return r.uploadToS3Target(pipeline.Context(), target, name, body, meta)
+	}
+	if err := budget.Acquire(pipeline.Context(), size); err != nil {
+		return err
+	}
+
+	stagedPath, err := stageReaderToTempPath(pipeline.Context(), r.s3Extract.stagingDir, "gotgz-tar-s3-extract-*", body)
+	if err != nil {
+		budget.Release(size)
+		return err
+	}
+
+	if err := pipeline.Submit(func(ctx context.Context) error {
+		defer budget.Release(size)
+		defer os.Remove(stagedPath) //nolint:errcheck
+
+		file, err := openStagedFileReader(stagedPath)
+		if err != nil {
+			return err
+		}
+		defer file.Close() //nolint:errcheck
+		return r.uploadToS3Target(ctx, target, name, file, meta)
+	}); err != nil {
+		budget.Release(size)
+		_ = os.Remove(stagedPath)
+		return err
+	}
+	return nil
+}

--- a/packages/engine/s3_extract_zip.go
+++ b/packages/engine/s3_extract_zip.go
@@ -1,0 +1,153 @@
+package engine
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/islishude/gotgz/packages/archivepath"
+	"github.com/islishude/gotgz/packages/archiveprogress"
+	"github.com/islishude/gotgz/packages/archiveutil"
+	"github.com/islishude/gotgz/packages/cli"
+	"github.com/islishude/gotgz/packages/locator"
+)
+
+// shouldUseConcurrentS3Extract reports whether this run should enable object-level
+// concurrency for archive extraction into S3.
+func (r *Runner) shouldUseConcurrentS3Extract(target locator.Ref) bool {
+	return target.Kind == locator.KindS3 && r.s3Extract.workers > 1
+}
+
+// withConcurrentS3ZipReader opens a zip.Reader suitable for concurrent entry uploads.
+func (r *Runner) withConcurrentS3ZipReader(ctx context.Context, archiveRef locator.Ref, ar io.ReadCloser, info archiveReaderInfo, _ *archiveprogress.Reporter, fn func(zr *zip.Reader) (int, error)) (int, error) {
+	if archiveRef.Kind == locator.KindLocal && info.SizeKnown && archiveRef.Path != "" {
+		f, err := os.Open(archiveRef.Path)
+		if err == nil {
+			defer f.Close() //nolint:errcheck
+			st, statErr := f.Stat()
+			if statErr == nil && st.Mode().IsRegular() {
+				zr, zipErr := zip.NewReader(f, st.Size())
+				if zipErr == nil {
+					return fn(zr)
+				}
+			}
+		}
+	}
+
+	enforceStagingLimit := zipStagingLimitApplies(archiveRef)
+	stagingLimit := zipStagingLimitBytes()
+	if enforceStagingLimit && info.SizeKnown && info.Size > stagingLimit {
+		return 0, zipStagingLimitError(archiveRef, stagingLimit)
+	}
+
+	limit := int64(-1)
+	if enforceStagingLimit {
+		limit = stagingLimit
+	}
+	staged, size, err := stageReaderToTempFileLimit(ctx, r.s3Extract.stagingDir, "gotgz-zip-s3-extract-*", ar, limit)
+	if err != nil {
+		if errors.Is(err, archiveutil.ErrCopyLimitExceeded) {
+			return 0, zipStagingLimitError(archiveRef, stagingLimit)
+		}
+		return 0, err
+	}
+	defer func() {
+		_ = cleanupTempFile(staged)
+	}()
+
+	if enforceStagingLimit && size > stagingLimit {
+		return 0, zipStagingLimitError(archiveRef, stagingLimit)
+	}
+
+	zr, err := zip.NewReader(staged, size)
+	if err != nil {
+		return 0, err
+	}
+	return fn(zr)
+}
+
+// extractZipEntriesToS3Concurrent uploads matching zip entries to S3 with one worker pool.
+func (r *Runner) extractZipEntriesToS3Concurrent(ctx context.Context, zr *zip.Reader, opts cli.Options, reporter *archiveprogress.Reporter, target locator.Ref, memberMatcher *archivepath.CompiledPathMatcher) (int, error) {
+	pipeline := newS3ExtractPipeline(ctx, r.s3Extract.workers)
+	warnings := 0
+
+	for _, zf := range zr.File {
+		select {
+		case <-pipeline.Context().Done():
+			return warnings, pipeline.Wait()
+		default:
+		}
+		if archivepath.ShouldSkipMemberWithMatcher(memberMatcher, zf.Name) {
+			continue
+		}
+		extractName, ok := archivepath.StripPathComponents(zf.Name, opts.StripComponents)
+		if !ok || extractName == "" {
+			continue
+		}
+		if opts.Verbose {
+			reporter.BeforeExternalLineOutput()
+			_, _ = fmt.Fprintln(r.stdout, extractName)
+			reporter.AfterExternalLineOutput()
+		}
+
+		name := strings.TrimPrefix(extractName, "./")
+		if name == "" || isZipDir(zf) {
+			continue
+		}
+		if !isZipRegular(zf) && !isZipSymlink(zf) {
+			warnings += r.warnf(reporter, "zip entry %s has unsupported type %s on S3 target; skipping", zf.Name, zf.Mode().String())
+			continue
+		}
+		if isZipSymlink(zf) {
+			warnings += r.warnf(reporter, "zip symlink %s extracted to S3 as regular object", zf.Name)
+		}
+		skip, w, err := r.probeZipEntry(zf, reporter)
+		warnings += w
+		if err != nil {
+			waitErr := pipeline.Wait()
+			if waitErr != nil {
+				return warnings, waitErr
+			}
+			return warnings, err
+		}
+		if skip {
+			continue
+		}
+
+		entry := zf
+		keyName := name
+		if err := pipeline.Submit(func(ctx context.Context) error {
+			rc, err := entry.Open()
+			if err != nil {
+				return err
+			}
+			defer rc.Close() //nolint:errcheck
+			return r.uploadToS3Target(ctx, target, keyName, archiveprogress.NewCountingReader(rc, reporter), target.Metadata)
+		}); err != nil {
+			waitErr := pipeline.Wait()
+			if waitErr != nil {
+				return warnings, waitErr
+			}
+			return warnings, err
+		}
+	}
+
+	return warnings, pipeline.Wait()
+}
+
+// probeZipEntry validates that one zip entry can be opened before the worker pool
+// emits verbose output and deterministic warnings in archive order.
+func (r *Runner) probeZipEntry(zf *zip.File, reporter *archiveprogress.Reporter) (bool, int, error) {
+	rc, err := zf.Open()
+	if err == nil {
+		return false, 0, rc.Close()
+	}
+	if errors.Is(err, zip.ErrAlgorithm) {
+		return true, r.warnf(reporter, "zip entry %s uses unsupported algorithm/encryption; skipping", zf.Name), nil
+	}
+	return false, 0, err
+}

--- a/packages/engine/zip_extract.go
+++ b/packages/engine/zip_extract.go
@@ -64,8 +64,15 @@ func (r *Runner) runExtractZip(ctx context.Context, opts cli.Options, reporter *
 	}
 
 	if len(volumes) == 1 {
-		zipWarnings, err := r.withZipReader(ctx, archiveRef, ar, info, nil, func(zr *zip.Reader) (int, error) {
+		readZip := r.withZipReader
+		if r.shouldUseConcurrentS3Extract(parsedTarget) {
+			readZip = r.withConcurrentS3ZipReader
+		}
+		zipWarnings, err := readZip(ctx, archiveRef, ar, info, nil, func(zr *zip.Reader) (int, error) {
 			reporter.SetTotal(matchingZipExtractPayloadBytes(zr, memberMatcher, opts.StripComponents), true)
+			if r.shouldUseConcurrentS3Extract(parsedTarget) {
+				return r.extractZipEntriesToS3Concurrent(ctx, zr, opts, reporter, parsedTarget, memberMatcher)
+			}
 			return r.extractZipEntries(ctx, zr, opts, reporter, parsedTarget, target, policy, safetyCache, memberMatcher)
 		})
 		return warnings + zipWarnings, err
@@ -84,7 +91,14 @@ func (r *Runner) runExtractZip(ctx context.Context, opts cli.Options, reporter *
 	}
 
 	zipWarnings, err := r.forEachArchiveVolume(ctx, volumes, firstReader, info, func(ref locator.Ref, reader io.ReadCloser, readerInfo archiveReaderInfo) (int, error) {
-		return r.withZipReader(ctx, ref, reader, readerInfo, nil, func(zr *zip.Reader) (int, error) {
+		readZip := r.withZipReader
+		if r.shouldUseConcurrentS3Extract(parsedTarget) {
+			readZip = r.withConcurrentS3ZipReader
+		}
+		return readZip(ctx, ref, reader, readerInfo, nil, func(zr *zip.Reader) (int, error) {
+			if r.shouldUseConcurrentS3Extract(parsedTarget) {
+				return r.extractZipEntriesToS3Concurrent(ctx, zr, opts, reporter, parsedTarget, memberMatcher)
+			}
 			return r.extractZipEntries(ctx, zr, opts, reporter, parsedTarget, target, policy, safetyCache, memberMatcher)
 		})
 	})

--- a/packages/storage/s3/config.go
+++ b/packages/storage/s3/config.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -10,6 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const (
+	defaultPartSizeMB          int64 = 16
+	defaultConcurrency               = 4
+	defaultExtractWorkers            = 8
+	defaultExtractStagingBytes int64 = 512 << 20
 )
 
 // New builds an S3 store using AWS SDK default configuration and gotgz S3
@@ -27,18 +35,7 @@ func New(ctx context.Context) (*Store, error) {
 		return nil, err
 	}
 
-	settings := Settings{
-		PartSizeMB:  16,
-		Concurrency: 4,
-		SSE:         strings.ToLower(strings.TrimSpace(defaultString(os.Getenv("GOTGZ_S3_SSE"), "AES256"))),
-		SSEKMSKeyID: strings.TrimSpace(os.Getenv("GOTGZ_S3_SSE_KMS_KEY_ID")),
-	}
-	if v, ok := int64FromEnv("GOTGZ_S3_PART_SIZE_MB"); ok && v > 0 {
-		settings.PartSizeMB = v
-	}
-	if v, ok := intFromEnv("GOTGZ_S3_CONCURRENCY"); ok && v > 0 {
-		settings.Concurrency = v
-	}
+	settings := parseSettingsFromEnv()
 
 	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) {
 		o.DisableLogOutputChecksumValidationSkipped = true
@@ -51,6 +48,40 @@ func New(ctx context.Context) (*Store, error) {
 		o.Concurrency = settings.Concurrency
 	})
 	return &Store{client: client, tm: tm, settings: settings}, nil
+}
+
+// parseSettingsFromEnv resolves gotgz S3 behavior flags from the environment.
+func parseSettingsFromEnv() Settings {
+	settings := Settings{
+		PartSizeMB:          defaultPartSizeMB,
+		Concurrency:         defaultConcurrency,
+		SSE:                 strings.ToLower(strings.TrimSpace(defaultString(os.Getenv("GOTGZ_S3_SSE"), "AES256"))),
+		SSEKMSKeyID:         strings.TrimSpace(os.Getenv("GOTGZ_S3_SSE_KMS_KEY_ID")),
+		ExtractWorkers:      defaultExtractWorkers,
+		ExtractStagingBytes: defaultExtractStagingBytes,
+		ExtractStagingDir:   defaultExtractStagingDir(),
+	}
+	if v, ok := int64FromEnv("GOTGZ_S3_PART_SIZE_MB"); ok && v > 0 {
+		settings.PartSizeMB = v
+	}
+	if v, ok := intFromEnv("GOTGZ_S3_CONCURRENCY"); ok && v > 0 {
+		settings.Concurrency = v
+	}
+	if v, ok := intFromEnv("GOTGZ_S3_EXTRACT_WORKERS"); ok {
+		settings.ExtractWorkers = v
+	}
+	if v, ok := int64FromEnv("GOTGZ_S3_EXTRACT_STAGING_BYTES"); ok && v > 0 {
+		settings.ExtractStagingBytes = v
+	}
+	if v := strings.TrimSpace(os.Getenv("GOTGZ_S3_EXTRACT_STAGING_DIR")); v != "" {
+		settings.ExtractStagingDir = v
+	}
+	return settings
+}
+
+// defaultExtractStagingDir returns the default temp root for staged S3 extract payloads.
+func defaultExtractStagingDir() string {
+	return filepath.Clean(os.TempDir())
 }
 
 // intFromEnv parses one integer environment variable and reports whether it

--- a/packages/storage/s3/config_test.go
+++ b/packages/storage/s3/config_test.go
@@ -1,0 +1,70 @@
+package s3
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSettingsFromEnvDefaults(t *testing.T) {
+	t.Setenv("GOTGZ_S3_PART_SIZE_MB", "")
+	t.Setenv("GOTGZ_S3_CONCURRENCY", "")
+	t.Setenv("GOTGZ_S3_SSE", "")
+	t.Setenv("GOTGZ_S3_SSE_KMS_KEY_ID", "")
+	t.Setenv("GOTGZ_S3_EXTRACT_WORKERS", "")
+	t.Setenv("GOTGZ_S3_EXTRACT_STAGING_BYTES", "")
+	t.Setenv("GOTGZ_S3_EXTRACT_STAGING_DIR", "")
+
+	got := parseSettingsFromEnv()
+	if got.PartSizeMB != defaultPartSizeMB {
+		t.Fatalf("PartSizeMB = %d, want %d", got.PartSizeMB, defaultPartSizeMB)
+	}
+	if got.Concurrency != defaultConcurrency {
+		t.Fatalf("Concurrency = %d, want %d", got.Concurrency, defaultConcurrency)
+	}
+	if got.SSE != "aes256" {
+		t.Fatalf("SSE = %q, want %q", got.SSE, "aes256")
+	}
+	if got.ExtractWorkers != defaultExtractWorkers {
+		t.Fatalf("ExtractWorkers = %d, want %d", got.ExtractWorkers, defaultExtractWorkers)
+	}
+	if got.ExtractStagingBytes != defaultExtractStagingBytes {
+		t.Fatalf("ExtractStagingBytes = %d, want %d", got.ExtractStagingBytes, defaultExtractStagingBytes)
+	}
+	if got.ExtractStagingDir != filepath.Clean(os.TempDir()) {
+		t.Fatalf("ExtractStagingDir = %q, want %q", got.ExtractStagingDir, filepath.Clean(os.TempDir()))
+	}
+}
+
+func TestParseSettingsFromEnvOverrides(t *testing.T) {
+	t.Setenv("GOTGZ_S3_PART_SIZE_MB", "32")
+	t.Setenv("GOTGZ_S3_CONCURRENCY", "12")
+	t.Setenv("GOTGZ_S3_SSE", " aws:kms ")
+	t.Setenv("GOTGZ_S3_SSE_KMS_KEY_ID", " key-id ")
+	t.Setenv("GOTGZ_S3_EXTRACT_WORKERS", "3")
+	t.Setenv("GOTGZ_S3_EXTRACT_STAGING_BYTES", "1048576")
+	t.Setenv("GOTGZ_S3_EXTRACT_STAGING_DIR", " /tmp/gotgz-stage ")
+
+	got := parseSettingsFromEnv()
+	if got.PartSizeMB != 32 {
+		t.Fatalf("PartSizeMB = %d, want 32", got.PartSizeMB)
+	}
+	if got.Concurrency != 12 {
+		t.Fatalf("Concurrency = %d, want 12", got.Concurrency)
+	}
+	if got.SSE != "aws:kms" {
+		t.Fatalf("SSE = %q, want %q", got.SSE, "aws:kms")
+	}
+	if got.SSEKMSKeyID != "key-id" {
+		t.Fatalf("SSEKMSKeyID = %q, want %q", got.SSEKMSKeyID, "key-id")
+	}
+	if got.ExtractWorkers != 3 {
+		t.Fatalf("ExtractWorkers = %d, want 3", got.ExtractWorkers)
+	}
+	if got.ExtractStagingBytes != 1048576 {
+		t.Fatalf("ExtractStagingBytes = %d, want 1048576", got.ExtractStagingBytes)
+	}
+	if got.ExtractStagingDir != "/tmp/gotgz-stage" {
+		t.Fatalf("ExtractStagingDir = %q, want %q", got.ExtractStagingDir, "/tmp/gotgz-stage")
+	}
+}

--- a/packages/storage/s3/store.go
+++ b/packages/storage/s3/store.go
@@ -12,10 +12,13 @@ type Store struct {
 }
 
 type Settings struct {
-	PartSizeMB  int64
-	Concurrency int
-	SSE         string
-	SSEKMSKeyID string
+	PartSizeMB          int64
+	Concurrency         int
+	SSE                 string
+	SSEKMSKeyID         string
+	ExtractWorkers      int
+	ExtractStagingBytes int64
+	ExtractStagingDir   string
 }
 
 type Metadata struct {
@@ -27,4 +30,9 @@ type Metadata struct {
 type ListedObject struct {
 	Key  string
 	Size int64
+}
+
+// Settings returns a copy of the store configuration derived from environment.
+func (s *Store) Settings() Settings {
+	return s.settings
 }


### PR DESCRIPTION
- Added tests for concurrent extraction of zip files from S3, ensuring uploads occur in parallel.
- Introduced s3_extract_config.go to manage S3 extraction configuration, including worker count and staging settings.
- Created s3_extract_pipeline.go to handle concurrent upload tasks and error management.
- Implemented staging for tar entries in s3_extract_tar.go, allowing for efficient uploads of smaller files.
- Developed s3_extract_zip.go to manage zip extraction with support for concurrent uploads.
- Enhanced zip extraction logic in zip_extract.go to utilize new concurrent extraction methods based on target type.
- Updated S3 configuration in config.go to include new settings for extraction workers and staging bytes.
- Added unit tests for S3 configuration parsing in config_test.go to validate default and overridden settings.